### PR TITLE
Use http not https for releases link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ to [Typelevel](http://typelevel.org/about.html).
 
 ### Getting Binaries
 
-See the [releases page on the website](https://scodec.org/releases/).
+See the [releases page on the website](http://scodec.org/releases/).
 
 Sign up for the [mailing list](https://groups.google.com/forum/#!forum/scodec) if you want to be notified of future releases.
 


### PR DESCRIPTION
There seems to be issues with the cert for scodec.org, and http links to it are used elsewhere (in scodec readme).