### PR TITLE
Update to FS2 0.10.0-M8 and Scala 2.12.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ scodecModule := "scodec-stream"
 scodecPrimaryModule
 scodecPrimaryModuleJvm
 
-crossScalaVersions := Seq(scalaVersion.value, "2.12.3") // fs2 does not support 2.10
+crossScalaVersions := Seq(scalaVersion.value, "2.12.4") // fs2 does not support 2.10
 
 contributors ++= Seq(Contributor("mpilquist", "Michael Pilquist"), Contributor("pchiusano", "Paul Chiusano"))
 
@@ -11,7 +11,7 @@ rootPackage := "scodec.stream"
 
 libraryDependencies ++= Seq(
   "org.scodec" %% "scodec-core" % "1.10.3",
-  "co.fs2" %% "fs2-core" % "0.10.0-M6",
+  "co.fs2" %% "fs2-core" % "0.10.0-M8",
   "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"
 )
 

--- a/src/main/scala/scodec/stream/decode/StreamDecoder.scala
+++ b/src/main/scala/scodec/stream/decode/StreamDecoder.scala
@@ -183,7 +183,7 @@ trait StreamDecoder[+A] { self =>
     through { s =>
       s.pull.uncons.flatMap {
         case None => Pull.fail(DecodingError(errIfEmpty))
-        case Some((hd,tl)) => Pull.output(hd) >> tl.pull.echo
+        case Some((hd,tl)) => Pull.output(hd) *> tl.pull.echo
       }.stream
     }
 
@@ -216,7 +216,7 @@ trait StreamDecoder[+A] { self =>
     through2(D.many[B]) { (value, delimiter) =>
       def decodeValue(vs: Stream[Pure, A], ds: Stream[Pure, B]): Pull[Pure,A,Unit] =
         vs.pull.uncons1.flatMap {
-          case Some((v,vs1)) => Pull.output1(v) >> decodeDelimiter(vs1,ds)
+          case Some((v,vs1)) => Pull.output1(v) *> decodeDelimiter(vs1,ds)
           case None => Pull.done
         }
       def decodeDelimiter(vs: Stream[Pure, A], ds: Stream[Pure, B]): Pull[Pure,A,Unit] =

--- a/src/main/scala/scodec/stream/decode/package.scala
+++ b/src/main/scala/scodec/stream/decode/package.scala
@@ -135,9 +135,9 @@ package object decode {
         case None => Pull.done
         case Some((bits, tl)) =>
           consume(A.value)(remainder ++ bits, Vector.empty) match {
-            case (rem, out, err: Err.InsufficientBits) => Pull.output(Chunk.seq(out)) >> waiting(rem)(tl)
+            case (rem, out, err: Err.InsufficientBits) => Pull.output(Chunk.seq(out)) *> waiting(rem)(tl)
             case (rem, Vector(), lastError) => Pull.fail(DecodingError(lastError))
-            case (rem, out, _) => Pull.output(Chunk.seq(out)) >> waiting(rem)(tl)
+            case (rem, out, _) => Pull.output(Chunk.seq(out)) *> waiting(rem)(tl)
           }
       }
     }
@@ -192,7 +192,7 @@ package object decode {
   // generic combinator, this could be added to fs2
   private def orImpl[F[_],A](s1: Stream[F,A], s2: Stream[F,A]): Stream[F,A] = {
     s1.pull.uncons.flatMap {
-      case Some((hd,tl)) => Pull.output(hd) >> tl.pull.echo
+      case Some((hd,tl)) => Pull.output(hd) *> tl.pull.echo
       case None => s2.pull.echo
     }.stream
   }

--- a/src/main/scala/scodec/stream/encode/package.scala
+++ b/src/main/scala/scodec/stream/encode/package.scala
@@ -32,13 +32,13 @@ package object encode {
         A.value.encode(a).fold(
           e => Pull.fail(EncodingError(e)),
           b => Pull.output1(b)
-        ) >> Pull.pure(Some(s1 -> empty))
+        ) *> Pull.pure(Some(s1 -> empty))
     }
   }
 
   /** A `StreamEncoder` that emits the given `BitVector`, then halts. */
   def emit[A](bits: BitVector): StreamEncoder[A] =
-    StreamEncoder.instance[A] { s => Pull.output1(bits) >> Pull.pure(Some(s -> empty[A])) }
+    StreamEncoder.instance[A] { s => Pull.output1(bits) *> Pull.pure(Some(s -> empty[A])) }
 
   /**
    * A `StreamEncoder` which encodes a single value, then halts.
@@ -50,7 +50,7 @@ package object encode {
       case Some((a, s1)) =>
         A.value.encode(a).fold(
           e => Pull.pure(Some(s1 -> empty)),
-          b => Pull.output1(b) >> Pull.pure(Some(s1 -> empty))
+          b => Pull.output1(b) *> Pull.pure(Some(s1 -> empty))
         )
     }
   }


### PR DESCRIPTION
The only migration needed so far was replacing `>>` with `*>`.